### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build_site:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/flowview/security/code-scanning/3](https://github.com/childmindresearch/flowview/security/code-scanning/3)

To fix the problem, explicitly set the permissions for the `build_site` job to the minimum required. Since none of the steps in `build_site` make API writes or deploy, they only need read access to the repository contents. Therefore, add a `permissions:` block to the `build_site` job with `contents: read`. This will restrict the GITHUB_TOKEN used in the job to the minimal privileges necessary, in line with security best practices. 

You only need to add:
```yaml
permissions:
  contents: read
```
under the `build_site` job, just before or after the `runs-on:` key (GitHub Actions allows either order, but placing it immediately after `runs-on:` is conventional).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
